### PR TITLE
fix tailwind misspelling on cursor-pointer

### DIFF
--- a/components/ui/navigation/main-navigation.tsx
+++ b/components/ui/navigation/main-navigation.tsx
@@ -5,7 +5,7 @@ export default function MainNavigation() {
     <nav className="flex justify-between items-center py-4 px-2 sm:px-4 bg-gray-700">
       <div className="relative w-10 h-10">
         <img
-          className="rounded-full curosr-pointer"
+          className="rounded-full cursor-pointer"
           src="https://i.pravatar.cc/40"
           alt=""
         />


### PR DESCRIPTION
Fixed image below...
<img width="450" height="39" alt="image" src="https://github.com/user-attachments/assets/8cd2f882-9b74-4e2a-8b1d-4cb24428a3dc" />
